### PR TITLE
Added to_dict() for exporting metadata

### DIFF
--- a/hgicommon/collections.py
+++ b/hgicommon/collections.py
@@ -16,6 +16,12 @@ class Metadata(Mapping):
         self._data = dict(seq)
         self._key_lock = defaultdict(Lock)    # type: Dict[Any, Lock]
 
+    def to_dict(self):
+        """
+        Exports the actual metadata as a dict with key: str, value: set(values).
+        """
+        return self._data
+        
     def rename(self, key: Any, new_key: Any):
         """
         Renames an item in this collection as a transaction.


### PR DESCRIPTION
I've finally got around to sorting out this repository... I've merged Irina's commits on the `master` branch into the `develop` branch. However, I don't think the functionality in this commit is needed though.

`Metadata` implements the `Mapping` interface (https://docs.python.org/3/library/collections.abc.html), in addition to having most of the methods defined in `MutableMapping`. It is subsequently nearly exactly the same, functionality, as a `dict` and, in most cases, can be treated in the same way as one.

If it is absolutely necessary to have a object of type `dict`, conversion is possible through use of the overloaded `dict` constructor that takes a `Mapping` instance as an argument:

```
dict(mapping) -> new dictionary initialized from a mapping object's (key, value) pairs
```

e.g. 

``` python
metadata_as_dict = dict(metadata)
```

Given the alternatives, I don't think the solution in this commit, which exposes a pointer to an internal variable, is required.
